### PR TITLE
Use ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read(".ruby-version").strip
+
 gem 'byebug'
 gem 'celluloid-io'
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,4 +139,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.1.4
+   2.3.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,5 +135,8 @@ DEPENDENCIES
   sinatra
   slack-ruby-bot
 
+RUBY VERSION
+   ruby 3.1.2p20
+
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
* Heroku ignores `.ruby-version`. Rather than specifying the version in
two places, risking they get out of sync, read the version into Gemfile.
* Update bundler version to eliminate the risk that old versions create
problems when deploying