### PR TITLE
Use action to create PR with updated acronyms

### DIFF
--- a/.github/workflows/rebuild_dictionary.yml
+++ b/.github/workflows/rebuild_dictionary.yml
@@ -30,8 +30,12 @@ jobs:
         SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
         GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
 
-    - name: Commit the updated dictionary
-      uses: stefanzweifel/git-auto-commit-action@v4
+    - name: Create pull request with updated dictionary
+      uses: peter-evans/create-pull-request@v4.1.1
       with:
-        commit_message: Update dictionary
-        file_pattern: config/acronyms.yml
+        add-paths: config/acronyms.yml
+        commit-message: Automatic dictionary update
+        branch: update-acronyms
+        delete-branch: true
+        title: Update acronyms with latest definitions
+        body: This is an automatically created PR to update the acronyms from the latest version of the dxw Glossary


### PR DESCRIPTION
The `main` branch is protected, so auto-committing isn't going to work unless we enable force pushes to this protected branch.

Let's use an action that opens a pull request instead, so we can be sure that a human reviewed the changes to the dictionary, and we can keep our branch protections as we like them.