### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES
   slack-ruby-bot
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.2.1p31
 
 BUNDLED WITH
    2.3.18


### PR DESCRIPTION
The Gemfile reads the ruby version from `.ruby-version`. When the ruby version changed to 3.2.1, the Gemfile wasn’t modified, so it didn’t trigger an update to Gemfile.lock either.

The CI wasn’t bothered by the mismatch, but Heroku was, and the deploy failed.