### PR TITLE
Switch to renovate shared config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["github>dxw/renovate-config:internal"]
 }


### PR DESCRIPTION
This switches off Dependabot for dependency updates, in favour of the [common Renovate config](https://github.com/dxw/renovate-config)