### PR TITLE
Replay unknown acronym to user

### DIFF
--- a/lib/acronym_bot.rb
+++ b/lib/acronym_bot.rb
@@ -10,6 +10,6 @@ post '/' do
   if first_match
     "#{first_match} stands for #{expansion[first_match]}"
   else
-    "Sorry, I don't know that acronym"
+    "Sorry, I don't know the acronym \"#{acronym}\""
   end
 end

--- a/spec/acronym_bot_spec.rb
+++ b/spec/acronym_bot_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Acronym bot' do
       let(:response) { post "/", text: "NOTEXISTINGACRONYM" }
 
       it "notifies the user that acronym does not exist in the yaml file" do
-        expect(response.body).to include("Sorry, I don't know that acronym")
+        expect(response.body).to include("Sorry, I don't know the acronym \"NOTEXISTINGACRONYM\"")
       end
     end
   end


### PR DESCRIPTION
When the user provides an acronym that's unknown, the bot currently just says "Sorry, I don't know that acronym". It would be nice to be able to see what you've entered/tried, so that you can see whether it was likely to be a typo versus an actually unknown acronym